### PR TITLE
Mark references/pointers as const where they can be to fix warnings

### DIFF
--- a/robotArm/command.cpp
+++ b/robotArm/command.cpp
@@ -91,7 +91,7 @@ Cmd Command::getCmd() const {
   return command; 
 }
 
-int Command::pos(String& s, char c, int start) {
+int Command::pos(String const& s, char c, int start) {
   int len = s.length();
   for (int i = start; i < len; i++) {
     if (c == s[i]) {
@@ -113,12 +113,12 @@ void printFault() {
   Serial.println("!!");
 }
 
-void printComment(char* c) {
+void printComment(const char* c) {
   Serial.print("// ");
   Serial.println(c);
 }
 
-void printComment(String& s) {
+void printComment(String const& s) {
   Serial.print("// ");
   Serial.println(s);
 }
@@ -127,11 +127,12 @@ void printOk() {
   Serial.println("ok"); 
 }
 
-void printStatus(String& s) {
+void printStatus(String const& s) {
   Serial.print("ok ");
   Serial.println(s);
 }
-void printStatus(char* c) {
+
+void printStatus(const char* c) {
   Serial.print("ok ");
   Serial.println(c);
 }

--- a/robotArm/command.h
+++ b/robotArm/command.h
@@ -21,22 +21,18 @@ class Command {
     bool processMessage(String& msg);
     Cmd getCmd() const;
   private: 
-    int pos(String& s, char c, int start = 0);
+    int pos(String const& s, char c, int start = 0);
     String message;
     Cmd command;
 };
 
 void printErr();
 void printFault();
-void printComment(char* c);
-void printComment(String& s);
-void printStatus(String& s);
-void printStatus(char* c);
+void printComment(const char* c);
+void printComment(String const& s);
+void printStatus(String const& s);
+void printStatus(const char* c);
+
 void printOk();
 
 #endif
-
-
-
-
-

--- a/robotArm/command.h
+++ b/robotArm/command.h
@@ -32,7 +32,6 @@ void printComment(const char* c);
 void printComment(String const& s);
 void printStatus(String const& s);
 void printStatus(const char* c);
-
 void printOk();
 
 #endif


### PR DESCRIPTION
I was seeing a bunch of these warnings when compiling on MacOS 10.15.5
```
warning: ISO C++ forbids converting a string constant to 'char*'
```